### PR TITLE
Deployment and Operational Guide Boilerplate Updates

### DIFF
--- a/deployment_steps_tf.adoc
+++ b/deployment_steps_tf.adoc
@@ -1,7 +1,5 @@
 Run the following commands from an IDE or terminal with terraform installed.
 
-. Clone the repository: git clone https://github.com/{quickstart-github-org}/{quickstart-project-name}
-. Navigate to the repository: cd {quickstart-project-name}
 . Initialize the environment: `+terraform init+`
 . Verify that the deployed architecture is correct: `+terraform plan+`
 . Validate the code: `+terraform validate+`

--- a/deployment_terraform/.specific/post_deployment.adoc
+++ b/deployment_terraform/.specific/post_deployment.adoc
@@ -1,3 +1,2 @@
 //Include any postdeployment steps here, such as steps necessary to test that the deployment was successful. If there are no postdeployment steps leave this file empty.
 
-== Postdeployment steps

--- a/deployment_terraform/.specific/pre_deployment.adoc
+++ b/deployment_terraform/.specific/pre_deployment.adoc
@@ -1,3 +1,6 @@
 //Include any predeployment steps here, such as signing up for a Marketplace AMI or making any changes to a Partner account. If there are none leave this file empty.
 
-== Predeployment steps
+. Clone the repository: git clone https://github.com/{quickstart-github-org}/{quickstart-project-name}
+. Navigate to the repository: cd {quickstart-project-name}
+
+//Add any additional steps that are necessary prior to deploying using terraform

--- a/deployment_terraform/_layout_deployment.adoc
+++ b/deployment_terraform/_layout_deployment.adoc
@@ -54,6 +54,7 @@ ifndef::production_build[]
 |===
 endif::production_build[]
 
+== Predeployment steps
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{guideroot}/{specificdir}/pre_deployment.adoc`**_
 [.preview_mode]
@@ -68,6 +69,7 @@ endif::production_build[]
 == Deployment steps
 include::../../{includedir}/deployment_steps_tf.adoc[]
 
+== Postdeployment steps
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{guideroot}/{specificdir}/post_deployment.adoc`**_
 [.preview_mode]

--- a/operational/_layout_operational.adoc
+++ b/operational/_layout_operational.adoc
@@ -1,6 +1,6 @@
 [.text-center]
 [discrete]
-== {partner-product-name} on the AWS Cloud - Operational Guide
+== {partner-product-name} on the AWS Cloud
 :doctitle: {partner-product-name} on the AWS Cloud - Operational guide
 :!toc:
 [.text-left]


### PR DESCRIPTION
Update to terraform deployment guide template to allow for more flexibility in the static deployment steps, moving pre and post deployment headers so that another TOC is not generated and removing redundant operation guide in the operational guide layout header