### PR TITLE
Use current year for copyright year

### DIFF
--- a/.common/docinfo-footer.html
+++ b/.common/docinfo-footer.html
@@ -3,6 +3,6 @@
         <!-- We can use document attributes: -->
         <!-- Generated with Asciidoctor v{asciidoctor-version}. -->
         <a href="https://aws.amazon.com/privacy/">Privacy</a> | <a href="https://aws.amazon.com/terms/">Site terms</a> |
-        &copy; 2022, Amazon Web Services, Inc. or its affiliates{partner-company-footer}. All rights reserved.
+        &copy; {current-year}, Amazon Web Services, Inc. or its affiliates{partner-company-footer}. All rights reserved.
     </p>
 </footer>

--- a/.utils/build_docs.sh
+++ b/.utils/build_docs.sh
@@ -18,7 +18,7 @@ build_guide_with_asciidoc_attributes() {
         ASCIIDOC_ATTRIBUTES="-a production_build"
     fi
     set -x
-    asciidoctor --base-dir docs/ --backend=html5 -o ${OUTPUT_FILE} -w --doctype=book -a toc2 ${ASCIIDOC_ATTRIBUTES} ${LAYOUT_FILE}
+    asciidoctor --base-dir docs/ --backend=html5 -o ${OUTPUT_FILE} -w --doctype=book -a toc2 -a current-year=$(date +%Y) ${ASCIIDOC_ATTRIBUTES} ${LAYOUT_FILE}
     set +x
 }
 


### PR DESCRIPTION
Improvement so that we no longer have to update the static copyright year in the footer every year.