### PR TITLE
A few small corrections

### DIFF
--- a/.common/customer_responsibility.adoc
+++ b/.common/customer_responsibility.adoc
@@ -1,3 +1,5 @@
 //DO NOT REMOVE THIS SECTION. For questions contact @ameighta
 
-After you successfully deploy a Quick Start, confirm that your resources and services are updated and configured—including any required patches—to meet your security and other needs. For more information, refer to the https://aws.amazon.com/compliance/shared-responsibility-model/[Shared Responsibility Model^].
+== Customer responsibility
+
+After you deploy a Quick Start, confirm that your resources and services are updated and configured—including any required patches—to meet your security and other needs. For more information, refer to the https://aws.amazon.com/compliance/shared-responsibility-model/[Shared Responsibility Model^].

--- a/_old/_layout_general.adoc
+++ b/_old/_layout_general.adoc
@@ -1,3 +1,5 @@
+//This is an old file, retained for reference only.
+
 [.text-center]
 [discrete]
 == AWS Quick Starts

--- a/_old/customer_responsibility.adoc
+++ b/_old/customer_responsibility.adoc
@@ -1,1 +1,3 @@
-After you successfully deploy this Quick Start, confirm that your resources and services are updated and configured—including any required patches—to meet your security and other needs. For more information, refer to the https://aws.amazon.com/compliance/shared-responsibility-model/[AWS Shared Responsibility Model].
+//This is an old file, retained for reference only.
+
+After you deploy this Quick Start, confirm that your resources and services are updated and configured—including any required patches—to meet your security and other needs. For more information, refer to the https://aws.amazon.com/compliance/shared-responsibility-model/[AWS Shared Responsibility Model].

--- a/_old/planning.adoc
+++ b/_old/planning.adoc
@@ -1,6 +1,8 @@
+//This is an old doc, retained for reference only. For the latest content, refer to the AWS Quick Starts General Info Guide (https://aws-ia.github.io/content/qs_info.html).
+
 === Specialized knowledge
 
-Quick Start deployments require a moderate level of familiarity with AWS services. If you're new to AWS, refer to https://aws.amazon.com/getting-started/[Getting Started Resource Center^] and https://aws.amazon.com/training/[AWS Training and Certification^]. These sites provide materials for learning how to design, deploy, and operate your infrastructure and applications on the AWS Cloud.
+Quick Start deployments require a moderate level of familiarity with AWS services. If you're new to AWS, refer to https://aws.amazon.com/getting-started/[Getting Started Resource Center^] and https://aws.amazon.com/training/[AWS Training and Certification^]. These sites provide materials for learning how to design, deploy, and operate your infrastructure and applications on AWS.
 
 === AWS account
 

--- a/_old/planning.adoc
+++ b/_old/planning.adoc
@@ -1,4 +1,4 @@
-//This is an old doc, retained for reference only. For the latest content, refer to the AWS Quick Starts General Info Guide (https://aws-ia.github.io/content/qs_info.html).
+//This is an old file, retained for reference only. For the latest content, refer to the AWS Quick Starts General Info Guide (https://aws-ia.github.io/content/qs_info.html).
 
 === Specialized knowledge
 

--- a/deployment_cdk/.specific/overview.adoc
+++ b/deployment_cdk/.specific/overview.adoc
@@ -1,4 +1,4 @@
-This Quick Start deploys {partner-product-name} on the AWS Cloud. This guide covers the steps necessary to deploy this Quick Start.
+This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the steps necessary to deploy this Quick Start.
 
 // For advanced information about the product, troubleshooting, or additional functionality, refer to the https://{quickstart-github-org}.github.io/{quickstart-project-name}/operational/index.html[Operational Guide^].
 

--- a/deployment_cdk/.specific/overview.adoc
+++ b/deployment_cdk/.specific/overview.adoc
@@ -1,4 +1,4 @@
-This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the information you need to deploy the Quick Start.
+This guide covers the information you need to deploy the {partner-product-name} Quick Start in the AWS Cloud.
 
 // For advanced information about the product, troubleshooting, or additional functionality, refer to the https://{quickstart-github-org}.github.io/{quickstart-project-name}/operational/index.html[Operational Guide^].
 

--- a/deployment_cdk/.specific/overview.adoc
+++ b/deployment_cdk/.specific/overview.adoc
@@ -1,4 +1,4 @@
-This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the steps necessary to deploy this Quick Start.
+This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the information you need to deploy the Quick Start.
 
 // For advanced information about the product, troubleshooting, or additional functionality, refer to the https://{quickstart-github-org}.github.io/{quickstart-project-name}/operational/index.html[Operational Guide^].
 

--- a/deployment_cdk/_layout_deployment.adoc
+++ b/deployment_cdk/_layout_deployment.adoc
@@ -6,8 +6,8 @@ ifndef::production_build[]
 endif::production_build[]
 [.text-center]
 [discrete]
-== {partner-product-name} on the AWS Cloud
-:doctitle: {partner-product-name} on the AWS Cloud for CDK
+== {partner-product-name} on AWS
+:doctitle: {partner-product-name} on AWS for CDK
 :!toc:
 [.text-left]
 include::../../{includedir}/introduction.adoc[]

--- a/deployment_cfn/.specific/overview.adoc
+++ b/deployment_cfn/.specific/overview.adoc
@@ -1,4 +1,4 @@
-This Quick Start deploys {partner-product-name} on the AWS Cloud. This guide covers the steps necessary to deploy this Quick Start.
+This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the steps necessary to deploy this Quick Start.
 
 // For advanced information about the product, troubleshooting, or additional functionality, refer to the https://{quickstart-github-org}.github.io/{quickstart-project-name}/operational/index.html[Operational Guide^].
 

--- a/deployment_cfn/.specific/overview.adoc
+++ b/deployment_cfn/.specific/overview.adoc
@@ -1,4 +1,4 @@
-This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the information you need to deploy the Quick Start.
+This guide covers the information you need to deploy the {partner-product-name} Quick Start in the AWS Cloud.
 
 // For advanced information about the product, troubleshooting, or additional functionality, refer to the https://{quickstart-github-org}.github.io/{quickstart-project-name}/operational/index.html[Operational Guide^].
 

--- a/deployment_cfn/.specific/overview.adoc
+++ b/deployment_cfn/.specific/overview.adoc
@@ -1,4 +1,4 @@
-This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the steps necessary to deploy this Quick Start.
+This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the information you need to deploy the Quick Start.
 
 // For advanced information about the product, troubleshooting, or additional functionality, refer to the https://{quickstart-github-org}.github.io/{quickstart-project-name}/operational/index.html[Operational Guide^].
 

--- a/deployment_cfn/_layout_deployment.adoc
+++ b/deployment_cfn/_layout_deployment.adoc
@@ -6,8 +6,8 @@ ifndef::production_build[]
 endif::production_build[]
 [.text-center]
 [discrete]
-== {partner-product-name} on the AWS Cloud
-:doctitle: {partner-product-name} on the AWS Cloud for CFN
+== {partner-product-name} on AWS
+:doctitle: {partner-product-name} on AWS for CFN
 :!toc:
 [.text-left]
 include::../../{includedir}/introduction.adoc[]

--- a/deployment_ct/.specific/overview.adoc
+++ b/deployment_ct/.specific/overview.adoc
@@ -1,4 +1,4 @@
-This Quick Start deploys {partner-product-name} on the AWS Cloud. This guide covers the steps necessary to deploy this Quick Start.
+This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the steps necessary to deploy this Quick Start.
 
 // For advanced information about the product, troubleshooting, or additional functionality, refer to the https://{quickstart-github-org}.github.io/{quickstart-project-name}/operational/index.html[Operational Guide^].
 

--- a/deployment_ct/.specific/overview.adoc
+++ b/deployment_ct/.specific/overview.adoc
@@ -1,4 +1,4 @@
-This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the information you need to deploy the Quick Start.
+This guide covers the information you need to deploy the {partner-product-name} Quick Start in the AWS Cloud.
 
 // For advanced information about the product, troubleshooting, or additional functionality, refer to the https://{quickstart-github-org}.github.io/{quickstart-project-name}/operational/index.html[Operational Guide^].
 

--- a/deployment_ct/.specific/overview.adoc
+++ b/deployment_ct/.specific/overview.adoc
@@ -1,4 +1,4 @@
-This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the steps necessary to deploy this Quick Start.
+This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the information you need to deploy the Quick Start.
 
 // For advanced information about the product, troubleshooting, or additional functionality, refer to the https://{quickstart-github-org}.github.io/{quickstart-project-name}/operational/index.html[Operational Guide^].
 

--- a/deployment_ct/_layout_deployment.adoc
+++ b/deployment_ct/_layout_deployment.adoc
@@ -6,8 +6,8 @@ ifndef::production_build[]
 endif::production_build[]
 [.text-center]
 [discrete]
-== {partner-product-name} on the AWS Cloud
-:doctitle: {partner-product-name} on the AWS Cloud — CFN
+== {partner-product-name} on AWS
+:doctitle: {partner-product-name} on AWS — CFN
 :!toc:
 [.text-left]
 include::../../{includedir}/introduction.adoc[]

--- a/deployment_ct/_layout_deployment.adoc
+++ b/deployment_ct/_layout_deployment.adoc
@@ -7,7 +7,7 @@ endif::production_build[]
 [.text-center]
 [discrete]
 == {partner-product-name} on AWS
-:doctitle: {partner-product-name} on AWS — CFN
+:doctitle: {partner-product-name} on AWS for CFN
 :!toc:
 [.text-left]
 include::../../{includedir}/introduction.adoc[]

--- a/deployment_eks/.specific/overview.adoc
+++ b/deployment_eks/.specific/overview.adoc
@@ -1,4 +1,4 @@
-This Quick Start deploys {partner-product-name} on the AWS Cloud. This guide covers the steps necessary to deploy this Quick Start.
+This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the steps necessary to deploy this Quick Start.
 
 // For advanced information about the product, troubleshooting, or additional functionality, refer to the https://{quickstart-github-org}.github.io/{quickstart-project-name}/operational/index.html[Operational Guide^].
 

--- a/deployment_eks/.specific/overview.adoc
+++ b/deployment_eks/.specific/overview.adoc
@@ -1,4 +1,4 @@
-This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the information you need to deploy the Quick Start.
+This guide covers the information you need to deploy the {partner-product-name} Quick Start in the AWS Cloud.
 
 // For advanced information about the product, troubleshooting, or additional functionality, refer to the https://{quickstart-github-org}.github.io/{quickstart-project-name}/operational/index.html[Operational Guide^].
 

--- a/deployment_eks/.specific/overview.adoc
+++ b/deployment_eks/.specific/overview.adoc
@@ -1,4 +1,4 @@
-This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the steps necessary to deploy this Quick Start.
+This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the information you need to deploy the Quick Start.
 
 // For advanced information about the product, troubleshooting, or additional functionality, refer to the https://{quickstart-github-org}.github.io/{quickstart-project-name}/operational/index.html[Operational Guide^].
 

--- a/deployment_eks/_layout_deployment.adoc
+++ b/deployment_eks/_layout_deployment.adoc
@@ -6,8 +6,8 @@ ifndef::production_build[]
 endif::production_build[]
 [.text-center]
 [discrete]
-== {partner-product-name} on the AWS Cloud
-:doctitle: {partner-product-name} on the AWS Cloud for EKS
+== {partner-product-name} on AWS
+:doctitle: {partner-product-name} on AWS for EKS
 :!toc:
 [.text-left]
 include::../../{includedir}/introduction.adoc[]

--- a/deployment_steps_cfn.adoc
+++ b/deployment_steps_cfn.adoc
@@ -6,7 +6,7 @@
 NOTE: Unless you are customizing the Quick Start templates for your own projects, don't change the default settings for the following Amazon Simple Storage Service (Amazon S3) parameters: *Quick Start S3 bucket name*, *Quick Start S3 bucket Region*, and *Quick Start S3 key prefix*. Changing these settings automatically updates code references to point to a new Quick Start location. For more information, refer to the https://fwd.aws/NwqYA?[AWS Quick Start Contributor's Guide^].
 +
 . On the *Configure stack options* page, you can https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html[specify tags^] (key-value pairs) for resources in your stack and https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html[set advanced options^]. When you finish, choose *Next*.
-. On the *Review* page, review and confirm the template settings. Under *Capabilities*, select all of the check boxes to acknowledge that the template creates IAM resources that might require the ability to automatically expand macros.
+. On the *Review* page, review and confirm the template settings. Under *Capabilities*, select all of the check boxes to acknowledge that the template creates AWS Identity and Access Management (IAM)  resources that might require the ability to automatically expand macros.
 . Choose *Create stack* to deploy the stack.
 . Monitor the stack's status, and when the status is *CREATE_COMPLETE*, the {partner-product-name} deployment is ready.
 . To view the created resources, choose the *Outputs* tab.

--- a/deployment_steps_ct.adoc
+++ b/deployment_steps_ct.adoc
@@ -8,7 +8,7 @@
 NOTE: Unless you are customizing the Quick Start templates for your own projects, don't change the default settings for the parameters *Quick Start S3 bucket name*, *Quick Start S3 bucket Region*, and *Quick Start S3 key prefix*. Changing these settings automatically updates code references to point to a new Quick Start location. For more information, refer to the https://fwd.aws/NwqYA?[AWS Quick Start Contributor's Guide^].
 +
 . On the *Configure stack options* page, you can https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html[specify tags^] (key-value pairs) for resources in your stack and https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html[set advanced options^]. When you finish, choose *Next*.
-. On the *Review* page, review and confirm the template settings. Under *Capabilities*, select the two check boxes to acknowledge that the template creates IAM resources that might require the ability to automatically expand macros.
+. On the *Review* page, review and confirm the template settings. Under *Capabilities*, select the two check boxes to acknowledge that the template creates AWS Identity and Access Management (IAM) resources that might require the ability to automatically expand macros.
 . Choose *Create stack* to deploy the stack.
 . Monitor the stack's status, and when the status is *CREATE_COMPLETE*, the {partner-product-name} deployment is ready.
 . To view the created resources, choose the *Outputs* tab.

--- a/deployment_steps_eks.adoc
+++ b/deployment_steps_eks.adoc
@@ -6,7 +6,7 @@
 NOTE: Unless you are customizing the Quick Start templates for your own projects, don't change the default settings for the following Amazon Simple Storage Service (Amazon S3) parameters: *Quick Start S3 bucket name*, *Quick Start S3 bucket Region*, and *Quick Start S3 key prefix*. Changing these settings automatically updates code references to point to a new Quick Start location. For more information, refer to the https://fwd.aws/NwqYA?[AWS Quick Start Contributor's Guide^].
 +
 . On the *Configure stack options* page, you can https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html[specify tags^] (key-value pairs) for resources in your stack and https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html[set advanced options^]. When you finish, choose *Next*.
-. On the *Review* page, review and confirm the template settings. Under *Capabilities*, select the two check boxes to acknowledge that the template creates IAM resources that might require the ability to automatically expand macros.
+. On the *Review* page, review and confirm the template settings. Under *Capabilities*, select the two check boxes to acknowledge that the template creates AWS Identity and Access Management (IAM) resources that might require the ability to automatically expand macros.
 . Choose *Create stack* to deploy the stack.
 . Monitor the stack's status, and when the status is *CREATE_COMPLETE*, the {partner-product-name} deployment is ready.
 . To view the created resources, choose the *Outputs* tab.

--- a/deployment_terraform/.specific/overview.adoc
+++ b/deployment_terraform/.specific/overview.adoc
@@ -1,4 +1,4 @@
-This Quick Start deploys {partner-product-name} on the AWS Cloud. This guide covers the steps necessary to deploy this Quick Start.
+This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the steps necessary to deploy this Quick Start.
 
 // For advanced information about the product, troubleshooting, or additional functionality, refer to the https://{quickstart-github-org}.github.io/{quickstart-project-name}/operational/index.html[Operational Guide^].
 

--- a/deployment_terraform/.specific/overview.adoc
+++ b/deployment_terraform/.specific/overview.adoc
@@ -1,4 +1,4 @@
-This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the steps necessary to deploy this Quick Start.
+This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the information you need to deploy the Quick Start to deploy this Quick Start.
 
 // For advanced information about the product, troubleshooting, or additional functionality, refer to the https://{quickstart-github-org}.github.io/{quickstart-project-name}/operational/index.html[Operational Guide^].
 

--- a/deployment_terraform/.specific/overview.adoc
+++ b/deployment_terraform/.specific/overview.adoc
@@ -1,4 +1,4 @@
-This Quick Start deploys {partner-product-name} in the AWS Cloud. This guide covers the information you need to deploy the Quick Start to deploy this Quick Start.
+This guide covers the information you need to deploy the {partner-product-name} Quick Start in the AWS Cloud.
 
 // For advanced information about the product, troubleshooting, or additional functionality, refer to the https://{quickstart-github-org}.github.io/{quickstart-project-name}/operational/index.html[Operational Guide^].
 

--- a/deployment_terraform/_layout_deployment.adoc
+++ b/deployment_terraform/_layout_deployment.adoc
@@ -6,8 +6,8 @@ ifndef::production_build[]
 endif::production_build[]
 [.text-center]
 [discrete]
-== {partner-product-name} on the AWS Cloud
-:doctitle: {partner-product-name} on the AWS Cloud for Terraform
+== {partner-product-name} on AWS
+:doctitle: {partner-product-name} on AWS for Terraform
 :!toc:
 [.text-left]
 include::../../{includedir}/introduction.adoc[]

--- a/index_deployment_guide.adoc
+++ b/index_deployment_guide.adoc
@@ -35,7 +35,7 @@ ifndef::partner-company-name[:partner-company-footer:]
 // ************************************************************************************************************************
 
 ifndef::custom_title[]
-:title: {partner-product-name} on the AWS Cloud
+:title: {partner-product-name} on AWS
 endif::custom_title[]
 ifdef::custom_title[]
 :title: {custom_title}

--- a/index_migration_guide.adoc
+++ b/index_migration_guide.adoc
@@ -5,7 +5,7 @@
 :specificdir: partner_editable
 :icons: font
 :toc2: left
-:toc-title: 
+:toc-title:
 :toclevels: 2
 :stylesheet: {includedir}/.css/ia-css.css
 
@@ -19,7 +19,7 @@ include::../docs/{guideroot}/{specificdir}/_settings.adoc[]
 // ******************************* do not change the location of the contents in this block *******************************
 // ************************************************************************************************************************
 
-// the next two lines are needed for quick starts that are not built with a partner, if removed, footer text is mangled for those quick starts. 
+// The next two lines are needed for Quick Starts that are not built with a partner. If removed, footer text is mangled for those Quick Starts.
 // They must be below _settings.adoc
 ifdef::partner-company-name[:partner-company-footer: {sp}and {partner-company-name}]
 ifndef::partner-company-name[:partner-company-footer:]
@@ -35,7 +35,7 @@ ifndef::partner-company-name[:partner-company-footer:]
 // ************************************************************************************************************************
 
 ifndef::custom_title[]
-:title: {partner-product-name} on the AWS Cloud—Migration Guide
+:title: {partner-product-name} on AWS—Migration Guide
 endif::custom_title[]
 ifdef::custom_title[]
 :title: {custom_title}

--- a/index_operational_guide.adoc
+++ b/index_operational_guide.adoc
@@ -5,7 +5,7 @@
 :specificdir: partner_editable
 :icons: font
 :toc2: left
-:toc-title: 
+:toc-title:
 :toclevels: 2
 :stylesheet: {includedir}/.css/ia-css.css
 
@@ -19,7 +19,7 @@ include::../docs/{guideroot}/{specificdir}/_settings.adoc[]
 // ******************************* do not change the location of the contents in this block *******************************
 // ************************************************************************************************************************
 
-// the next two lines are needed for quick starts that are not built with a partner, if removed, footer text is mangled for those quick starts. 
+// The next two lines are needed for Quick Starts that are not built with a partner. If removed, footer text is mangled for those Quick Starts.
 // They must be below _settings.adoc
 ifdef::partner-company-name[:partner-company-footer: {sp}and {partner-company-name}]
 ifndef::partner-company-name[:partner-company-footer:]
@@ -35,7 +35,7 @@ ifndef::partner-company-name[:partner-company-footer:]
 // ************************************************************************************************************************
 
 ifndef::custom_title[]
-:title: {partner-product-name} on the AWS Cloud—Operational Guide
+:title: {partner-product-name} on AWS—Operational Guide
 endif::custom_title[]
 ifdef::custom_title[]
 :title: {custom_title}

--- a/migration/_layout_migration.adoc
+++ b/migration/_layout_migration.adoc
@@ -6,8 +6,8 @@ ifndef::production_build[]
 endif::production_build[]
 [.text-center]
 [discrete]
-== {partner-product-name} on the AWS Cloud—Migration Guide
-:doctitle: {partner-product-name} on the AWS Cloud—Migration Guide
+== {partner-product-name} on AWS—Migration Guide
+:doctitle: {partner-product-name} on AWS—Migration Guide
 :!toc:
 [.text-left]
 include::../../{includedir}/introduction_migration.adoc[]

--- a/operational/_layout_operational.adoc
+++ b/operational/_layout_operational.adoc
@@ -6,8 +6,8 @@ ifndef::production_build[]
 endif::production_build[]
 [.text-center]
 [discrete]
-== {partner-product-name} on the AWS Cloud
-:doctitle: {partner-product-name} on the AWS Cloud—Operational Guide
+== {partner-product-name} on AWS
+:doctitle: {partner-product-name} on AWS—Operational Guide
 :!toc:
 [.text-left]
 include::../../{includedir}/introduction_operational.adoc[]


### PR DESCRIPTION
* In titles and overviews, per AWS style, changed "on the AWS Cloud" to "on AWS" or "in the AWS Cloud."
* Spelled out "IAM."
* Restored the "Customer responsibility" heading.