### PR TITLE
Fix for Nav logo in operational guides

### DIFF
--- a/.css/ia-operational.css
+++ b/.css/ia-operational.css
@@ -1,4 +1,4 @@
-@import url("ia-css.css");
+@import url("./ia-css.css");
 
 #toc.toc2 #toctitle {
   background-image: url("../docs/boilerplate/.images/AWS-Logo.svg");

--- a/.css/ia-operational.css
+++ b/.css/ia-operational.css
@@ -1,0 +1,5 @@
+@import url("ia-css.css");
+
+#toc.toc2 #toctitle {
+  background-image: url("../docs/boilerplate/.images/AWS-Logo.svg");
+}

--- a/index_migration_guide.adoc
+++ b/index_migration_guide.adoc
@@ -7,7 +7,7 @@
 :toc2: left
 :toc-title:
 :toclevels: 2
-:stylesheet: {includedir}/.css/ia-css.css
+:stylesheet: {includedir}/.css/ia-operational.css
 
 // get the path to the layout file {:layout:}
 // this defines the program language of the guide (CFN, CDK, TF, EKS)

--- a/index_operational_guide.adoc
+++ b/index_operational_guide.adoc
@@ -7,7 +7,7 @@
 :toc2: left
 :toc-title:
 :toclevels: 2
-:stylesheet: {includedir}/.css/ia-css.css
+:stylesheet: {includedir}/.css/ia-operational.css
 
 // get the path to the layout file {:layout:}
 // this defines the program language of the guide (CFN, CDK, TF, EKS)


### PR DESCRIPTION
- Adding new css file for ops. This imports the existing css and overwrites the configured image location.
- Updating the operational and migration layout files for pointing to the new ia-operational.css file.